### PR TITLE
Remove HowOldIs link

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,8 +62,8 @@
 
     <div class="hero12">
       <h2>Nix Channel Status</h2>
-      <p>See <a href="http://howoldis.herokuapp.com/">HowOldIs</a> and the <a
-          href="https://nixos.wiki/wiki/Nix_channels">NixOS Wiki</a> for information on how channel updates progress.
+      <p>See the <a href="https://nixos.wiki/wiki/Nix_channels">NixOS Wiki</a>
+      for information on how channel updates progress.
       </p>
     </div>
 


### PR DESCRIPTION
According to the HowOldIs' Readme, it is not functional anymore and
replaced by https://status.nixos.org/