### PR TITLE
Switch from 'current' to 'status' for the labels

### DIFF
--- a/status.css
+++ b/status.css
@@ -43,3 +43,7 @@
     padding-top: 3em;
     padding-bottom: 3em;
 }
+
+.label {
+    margin-right: 0.2em;
+}


### PR DESCRIPTION
This adds a lot more label values with appropriate colors by reading the
'status' metric.

It also hides 'build problem' for EOL channels and pads the labels a bit
to make it look prettier.

Looks like this:
![image](https://user-images.githubusercontent.com/4971975/160633289-678cc65b-eb10-41e8-b0fe-40032347e5e3.png)

cc @samueldr since I don't know if "Stable" and "Rolling" are too noisy and @grahamc said you could judge that ;)