### PR TITLE
Stabilize channel sorting

### DIFF
--- a/status.js
+++ b/status.js
@@ -139,12 +139,20 @@ function split_channel(channel) {
 }
 
 function normalize_channel(channel) {
-  parts = split_channel(channel);
+  const parts = split_channel(channel);
   return [parts['time'], parts['collection'], parts['qualifier']].join("-");
 }
 
 function cmp_channels(left, right) {
-  return normalize_channel(left) < normalize_channel(right)
+  const norm_left = normalize_channel(left);
+  const norm_right = normalize_channel(right);
+  if (norm_left < norm_right) {
+    return 1;
+  } else if (norm_left > norm_right) {
+    return -1;
+  } else {
+    return 0;
+  }
 }
 
 init


### PR DESCRIPTION
This has always worked correctly on Firefox:

![image](https://github.com/NixOS/nixos-status/assets/76716/1d6505ab-e608-424b-abd0-0e4d82c104a8)


but not on Chrome:

![image](https://github.com/NixOS/nixos-status/assets/76716/869d18f4-3113-4be3-a7f5-43f7a39a758b)

... turns out we needed the sort function to return -1/0/1 instead of just bool, but Firefox was probably doing extra work to make it be what we wanted.