### PR TITLE
Update urls to prometheus/grafana

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,8 +45,8 @@
 
         <div class="nav-collapse collapse">
           <ul class="nav pull-left">
-            <li><a href="https://monitoring.nixos.org/grafana">Grafana</a></li>
-            <li><a href="https://monitoring.nixos.org/prometheus">Prometheus</a></li>
+            <li><a href="https://grafana.nixos.org">Grafana</a></li>
+            <li><a href="https://prometheus.nixos.org">Prometheus</a></li>
           </ul>
         </div>
       </div>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,11 @@
 [[redirects]]
   from = "/grafana/*"
-  to = "https://monitoring.nixos.org/grafana/:splat"
+  to = "https://grafana.nixos.org/:splat"
   status = 200
   force = true
 
 [[redirects]]
   from = "/prometheus/*"
-  to = "https://monitoring.nixos.org/prometheus/:splat"
+  to = "https://prometheus.nixos.org/:splat"
   status = 200
   force = true

--- a/status.js
+++ b/status.js
@@ -46,7 +46,7 @@ async function fetchMetrics(queryType, queryArgs = {}) {
     params.set(key, String(value));
   }
 
-  const response = await fetch(`https://monitoring.nixos.org/prometheus/api/v1/${queryType}?${params}`);
+  const response = await fetch(`https://prometheus.nixos.org/api/v1/${queryType}?${params}`);
   const {
     data
   } = await response.json();


### PR DESCRIPTION
Hi from the infra team,

we are moving these services to dedicated domains. The old paths are already redirecting.

