### PR TITLE
Fix wiki link for channels

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -62,7 +62,7 @@
 
     <div class="hero12">
       <h2>Nix Channel Status</h2>
-      <p>See the <a href="https://wiki.nixos.org/wiki/Nix_channels">NixOS Wiki</a>
+      <p>See the <a href="https://wiki.nixos.org/wiki/Channel_branches">NixOS Wiki</a>
         for information on how channel updates progress.
       </p>
     </div>


### PR DESCRIPTION
The `NixOS Wiki` link on https://status.nixos.org/ points to a 404 page. It seems the hostname was updated to the official wiki, without the page being updated.