### PR TITLE
Fix mobile overflow fix and navbar dark mode support

### DIFF
--- a/www/css/status.css
+++ b/www/css/status.css
@@ -58,6 +58,10 @@ a:hover img.logo {
     transform: rotate(120deg);
 }
 
+.table-striped {
+    display: block;
+    overflow-x: auto;
+}
 
 @media screen and (prefers-color-scheme: dark) {
     html {
@@ -87,6 +91,22 @@ a:hover img.logo {
         text-shadow: none;
     }
 
+    .nav-collapse .nav > li > a:hover,
+    .nav-collapse .nav > li > a:focus,
+    .nav-collapse .dropdown-menu a:hover,
+    .nav-collapse .dropdown-menu a:focus {
+        background-color: #3c3c3c;
+    }
+
+    .navbar .btn-navbar {
+        background: #00000000;
+    }
+    
+    .navbar .btn-navbar:hover, 
+    .navbar .btn-navbar:focus {
+        background-color: #4a4a4a;
+    }
+
     .caret {
         border-top: 4px solid #fafafa;
     }
@@ -114,6 +134,11 @@ a:hover img.logo {
     */
     .table-striped tr:nth-of-type(2n+1) td {
         background-color: initial !important;
+    }
+
+    .table-striped {
+        scrollbar-width: thin;
+        scrollbar-color: #5c5c5c #2d2d2d;
     }
 
     td {


### PR DESCRIPTION
<img width="901" alt="image" src="https://github.com/user-attachments/assets/8559febb-833c-4fd4-960c-64d11e687a87" />

### error version

```
firefox:
"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:139.0) Gecko/20100101 Firefox/139.0" 

chrome:
'Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.6 Mobile/15E148 Safari/604.1'
```