### PR TITLE
Harden CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ permissions:
   deployments: "write"
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.head_ref || github.ref_name }}"
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
   cancel-in-progress: true
 
 jobs:
@@ -28,10 +28,12 @@ jobs:
     steps:
 
       - name: "Checking out the repository"
-        uses: "actions/checkout@v7"
+        uses: "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0" # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: "Installing Nix"
-        uses: "cachix/install-nix-action@v31"
+        uses: "cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3" # v31.10.6
 
       - name: "Build"
         run: |
@@ -41,7 +43,7 @@ jobs:
 
       - name: "Publish to Netlify"
         if: ${{ github.repository == 'NixOS/nixos-status' }}
-        uses: "nwtgck/actions-netlify@v4.0.0"
+        uses: "nwtgck/actions-netlify@d22a32a27c918fe470bbc562e984f80ec48c2668" # v4.0.0
         env:
           NETLIFY_AUTH_TOKEN: "${{ secrets.NETLIFY_AUTH_TOKEN }}"
           NETLIFY_SITE_ID: "${{ secrets.NETLIFY_SITE_ID }}"


### PR DESCRIPTION
* Pin actions to specific commits
* Do not persist credentials after cloning the sources
* Adjust the concurrency group to make sure the PRs cannot cancel production deployments

Assisted-by: Findings spotted by Zizmor & Anthropic scan (ANT-2026-3CE4E6SN)